### PR TITLE
Prevent system icons from vanishing

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -29,5 +29,6 @@ package() {
 
   cd kde
   kpackagetool5 -p "$pkgdir/usr/share/plasma/plasmoids/" -t Plasma/Applet -i plasmoid
+  rm "$pkgdir/usr/share/plasma/plasmoids/kpluginindex.json"
 }
 


### PR DESCRIPTION
kpackagetool apparently creates a plugin index with just panon in it, making the system tray not display anything.