### PR TITLE
Add Solus dependencies install

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,6 +29,12 @@ sudo apt-get install qml-module-qt-websockets \
     python3-docopt python3-numpy python3-pyaudio python3-cffi python3-websockets
 #+END_SRC
 
+*** Solus
+#+BEGIN_SRC sh
+sudo eopkg install qt5-websockets  \
+   python-docopt PyAudio numpy python-cffi python-websockets
+#+END_SRC
+
 ** Installation
 *** Via KDE Store
 


### PR DESCRIPTION
Finally, It wasn’t pretty hard to find the right dependencies for Solus.  
Everything seems to work fine on it. From the audio ports, to the extensions downloads.

![](https://user-images.githubusercontent.com/13170204/94832569-5827f900-040e-11eb-99ed-af3579fe2923.png)