### PR TITLE
Add transparent background option

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -83,6 +83,9 @@
     <entry name="hideTooltip" type="Bool">
       <default>true</default>
     </entry>
+    <entry name="transparentBackground" type="Bool">
+      <default>false</default>
+    </entry>
 
 
   </group>

--- a/plasmoid/contents/ui/config/ConfigGeneral.qml
+++ b/plasmoid/contents/ui/config/ConfigGeneral.qml
@@ -17,6 +17,7 @@ Kirigami.FormLayout {
     property alias cfg_fps: fps.value
     property alias cfg_showFps: showFps.checked
     property alias cfg_hideTooltip: hideTooltip.checked
+    property alias cfg_transparentBackground: transparentBackground.checked
 
     property alias cfg_preferredWidth: preferredWidth.value
     property alias cfg_autoExtend: autoExtend.checked
@@ -95,6 +96,11 @@ Kirigami.FormLayout {
     QQC2.CheckBox {
         id:hideTooltip
         text: i18nc("@option:check", "Hide tooltip")
+    }
+
+    QQC2.CheckBox {
+        id:transparentBackground
+        text: i18nc("@option:check", "Transparent Background")
     }
 
     RowLayout {

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -12,7 +12,7 @@ Item {
 
     Plasmoid.toolTipItem: cfg.hideTooltip?tooltipitem:null
 
-    Plasmoid.backgroundHints: PlasmaCore.Types.DefaultBackground | PlasmaCore.Types.ConfigurableBackground
+    Plasmoid.backgroundHints: cfg.transparentBackground? "NoBackground" : PlasmaCore.Types.DefaultBackground | PlasmaCore.Types.ConfigurableBackground
 
     Item{id:tooltipitem}
 


### PR DESCRIPTION
Just what the title says. Currently it looks like this.
![image](https://user-images.githubusercontent.com/56965282/106332715-56335100-62ad-11eb-98ab-55eb12a6c4ff.png)
And I want it to look like
![image](https://user-images.githubusercontent.com/56965282/106332899-a27e9100-62ad-11eb-81e0-081937273902.png)

I was unable to find any option to do so (if I didn't miss anything that is) and was able to get it working (the second image is from my fork) and made a pr for the same.